### PR TITLE
Don't throw an exception if the bot cannot read the message history from a channel

### DIFF
--- a/src/main/java/io/github/nucleuspowered/proton/task/UpdateGuildMessageCache.java
+++ b/src/main/java/io/github/nucleuspowered/proton/task/UpdateGuildMessageCache.java
@@ -1,9 +1,11 @@
 package io.github.nucleuspowered.proton.task;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Message;
-import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.utils.PermissionUtil;
 
 public class UpdateGuildMessageCache implements Runnable {
 
@@ -16,10 +18,11 @@ public class UpdateGuildMessageCache implements Runnable {
     }
 
     @Override public void run() {
-        for (TextChannel channel : guild.getTextChannels()) {
+        final Member member = this.guild.getMember(this.guild.getJDA().getSelfUser());
+        guild.getTextChannels().stream().filter(x -> PermissionUtil.checkPermission(x, member, Permission.MESSAGE_HISTORY)).forEach(channel -> {
             for (Message message : channel.getHistory().retrievePast(100).complete()) {
                 cache.put(message.getId(), message);
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
It was failing because I don't want it acting on announcements or github-events, for example.

I've just done this for now, but if you have a better fix, I'm happy for it.